### PR TITLE
implement ToURLValues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# Text editor and miscellaneous files
+*.sw[op]
+*.DS_Store

--- a/otils.go
+++ b/otils.go
@@ -1,0 +1,196 @@
+package otils
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"reflect"
+	"strings"
+)
+
+// ToURLValues transforms any type with fields into a url.Values map
+// so that it can be used to make the QUERY string in HTTP GET requests
+// for example:
+//
+// Transforming a struct whose JSON representation is:
+// {
+//    "url": "https://orijtech.com",
+//    "logo": {
+//	"url": "https://orijtech.com/favicon.ico",
+//	"dimens": {
+//	  "width": 100, "height": 120,
+//	  "extra": {
+//	    "overlap": true,
+//	    "shade": "48%"
+//	  }
+//	}
+//    }
+// }
+//
+// Into:
+// "logo.dimension.extra.shade=48%25&logo.dimension.extra.zoom=false&logo.dimension.height=120&logo.dimension.width=100&logo.url=https%3A%2F%2Forijtech.com%2Ffavicon.ico"
+func ToURLValues(v interface{}) (url.Values, error) {
+	val := reflect.ValueOf(v)
+
+	switch val.Kind() {
+	case reflect.Ptr:
+		val = reflect.Indirect(val)
+	case reflect.Struct:
+		// Let this pass through
+	case reflect.Array, reflect.Slice:
+		return toURLValuesForSlice(v)
+	case reflect.Map:
+		return toURLValuesForMap(v)
+	default:
+		return nil, nil
+	}
+
+	fullMap := make(url.Values)
+	if !val.IsValid() {
+		return nil, errInvalidValue
+	}
+
+	typ := val.Type()
+	nfields := val.NumField()
+
+	for i := 0; i < nfields; i++ {
+		fieldVal := val.Field(i)
+		if fieldVal.Kind() == reflect.Ptr {
+			fieldVal = reflect.Indirect(fieldVal)
+		}
+
+		fieldTyp := typ.Field(i)
+		jsonTag := firstJSONTag(fieldTyp)
+
+		switch fieldVal.Kind() {
+		case reflect.Map:
+			keys := fieldVal.MapKeys()
+
+			for _, key := range keys {
+				value := fieldVal.MapIndex(key)
+				vIface := value.Interface()
+				innerValueMap, err := ToURLValues(vIface)
+				if err == nil && innerValueMap == nil {
+					if !isBlank(vIface) {
+						keyname := strings.Join([]string{jsonTag, fmt.Sprintf("%v", key)}, ".")
+						fullMap.Add(keyname, fmt.Sprintf("%v", vIface))
+					}
+					continue
+				}
+
+				for key, innerValueList := range innerValueMap {
+					keyname := strings.Join([]string{jsonTag, key}, ".")
+					fullMap[keyname] = append(fullMap[keyname], innerValueList...)
+				}
+			}
+
+		case reflect.Struct:
+			n := fieldVal.NumField()
+			typ := fieldVal.Type()
+			for i := 0; i < n; i++ {
+				ffield := fieldVal.Field(i)
+				fTyp := typ.Field(i)
+				keyname := strings.Join([]string{jsonTag, firstJSONTag(fTyp)}, ".")
+
+				fIface := ffield.Interface()
+				innerValueMap, err := ToURLValues(fIface)
+				if err == nil && innerValueMap == nil {
+					if !isBlank(fIface) {
+						fullMap.Add(keyname, fmt.Sprintf("%v", fIface))
+					}
+					continue
+				}
+
+				for key, innerValueList := range innerValueMap {
+					keyname := strings.Join([]string{keyname, key}, ".")
+					fullMap[keyname] = append(fullMap[keyname], innerValueList...)
+				}
+			}
+
+		default:
+			aIface := fieldVal.Interface()
+			if !isBlank(aIface) {
+				keyname := jsonTag
+				fullMap[keyname] = append(fullMap[keyname], fmt.Sprintf("%v", aIface))
+			}
+		}
+	}
+
+	return fullMap, nil
+}
+
+func toURLValuesForSlice(v interface{}) (url.Values, error) {
+	val := reflect.ValueOf(v)
+	n := val.Len()
+	finalValues := make(url.Values)
+
+	sliceValues := val.Slice(0, val.Len())
+	for i := 0; i < n; i++ {
+		ithVal := sliceValues.Index(i)
+		iface := ithVal.Interface()
+		// Goal here is to recombine them into
+		// {0: url.Values}
+		retr, _ := ToURLValues(iface)
+		if len(retr) > 0 {
+			key := fmt.Sprintf("%d", i)
+			finalValues[key] = append(finalValues[key], retr.Encode())
+		}
+	}
+
+	return finalValues, nil
+}
+
+func toURLValuesForMap(v interface{}) (url.Values, error) {
+	val := reflect.ValueOf(v)
+	keys := val.MapKeys()
+
+	fullMap := make(url.Values)
+	for _, key := range keys {
+		value := val.MapIndex(key)
+		vIface := value.Interface()
+		keyname := fmt.Sprintf("%v", key)
+		innerValueMap, err := ToURLValues(vIface)
+		if err == nil && innerValueMap == nil {
+			if !isBlank(vIface) {
+				fullMap.Add(keyname, fmt.Sprintf("%v", vIface))
+			}
+			continue
+		}
+
+		for key, innerValueList := range innerValueMap {
+			innerKeyname := strings.Join([]string{keyname, key}, ".")
+			fullMap[innerKeyname] = append(fullMap[innerKeyname], innerValueList...)
+		}
+	}
+
+	return fullMap, nil
+}
+
+// isBlank returns true if a value will leave a value blank in a URL Query string
+// e.g:
+//  * `value=`
+//  * `value=null`
+func isBlank(v interface{}) bool {
+	switch v {
+	case "", nil:
+		return true
+	default:
+		return false
+	}
+}
+
+var errInvalidValue = errors.New("invalid value")
+
+func firstJSONTag(v reflect.StructField) string {
+	jsonTag := v.Tag.Get("json")
+	if jsonTag == "" {
+		jsonTag = v.Name
+	} else {
+		// In the case that we have say `json:"name,omitempty"`
+		// we only want "name" as the tag, the rest
+		splits := strings.Split(jsonTag, ",")
+		jsonTag = splits[0]
+	}
+	return jsonTag
+}
+

--- a/otils_test.go
+++ b/otils_test.go
@@ -1,0 +1,107 @@
+package otils_test
+
+import (
+	"testing"
+
+	"github.com/orijtech/otils"
+)
+
+func TestToURLValues(t *testing.T) {
+	tests := [...]struct {
+		v       interface{}
+		want    string
+		mustErr bool
+	}{
+		0: {
+			v: &Request{
+				Source: "https://orijtech.com",
+				Logo: &Logo{
+					URL: "https://orijtech.com/favicon.ico",
+					Dimensions: &Dimension{
+						Width: 100, Height: 120,
+						Extra: map[string]interface{}{
+							"zoom": false, "shade": "45%",
+						},
+					},
+				},
+			},
+			want: "logo.dimension.extra.shade=45%25&logo.dimension.extra.zoom=false&logo.dimension.height=120&logo.dimension.width=100&logo.url=https%3A%2F%2Forijtech.com%2Ffavicon.ico&source=https%3A%2F%2Forijtech.com",
+		},
+
+		1: {
+			v:       nil,
+			mustErr: true,
+		},
+
+		2: {
+			v:       "thisway",
+			mustErr: true,
+		},
+
+		3: {
+			v: Request{
+				Logo: &Logo{
+					URL: "https://orijtech.com/favicon.ico",
+					Dimensions: &Dimension{
+						Width: 100, Height: 120,
+						Extra: map[string]interface{}{
+							"zoom": false, "shade": "0%",
+						},
+					},
+				},
+			},
+			want: "logo.dimension.extra.shade=0%25&logo.dimension.extra.zoom=false&logo.dimension.height=120&logo.dimension.width=100&logo.url=https%3A%2F%2Forijtech.com%2Ffavicon.ico",
+		},
+
+		4: {
+			v: []*Request{
+				{Logo: &Logo{URL: "https://orijtech.com/favicon.ico"}},
+				nil,
+			},
+			want: "0=logo.url%3Dhttps%253A%252F%252Forijtech.com%252Ffavicon.ico",
+		},
+
+		5: {
+			v:    map[string]int{"uno": 1, "zero": 0, "satu": 3, "saba": 7},
+			want: "saba=7&satu=3&uno=1&zero=0",
+		},
+
+		6: {
+			v:       func() int { return 2 },
+			mustErr: true,
+		},
+	}
+
+	for i, tt := range tests {
+		values, err := otils.ToURLValues(tt.v)
+		if tt.mustErr {
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("#%d: err: %v", i, err)
+			continue
+		}
+		got, want := values.Encode(), tt.want
+		if got != want {
+			t.Errorf("#%d:\ngot:  %q\nwant: %q", i, got, want)
+		}
+	}
+}
+
+type Dimension struct {
+	Width  int `json:"width"`
+	Height int `json:"height"`
+
+	Extra map[string]interface{} `json:"extra,omitempty"`
+}
+
+type Logo struct {
+	URL        string     `json:"url"`
+	Dimensions *Dimension `json:"dimension"`
+}
+
+type Request struct {
+	Logo   *Logo  `json:"logo"`
+	Source string `json:"source"`
+}


### PR DESCRIPTION
ToURLValues implements the functionality for transforming any
* Slice, Array
* Map
* Struct
* Pointer

into a url.Values that can then be encoded into a URL QUERY string.

The use case for this functionality is to implement a Go API client
for a partner that nests their content into a QUERY string e.g

"logo.dimension.extra.shade=48%25&logo.dimension.extra.zoom=false&logo.dimension.height=120&logo.dimension.width=100&logo.url=https%3A%2F%2Forijtech.com%2Ffavicon.ico"

Which would have been implemented as
```JSON
{
   "url": "https://orijtech.com",
   "logo": {
     "url": "https://orijtech.com/favicon.ico",
     "dimens": {
       "width": 100, "height": 100,
       "extra": {
         "overlap": true,
         "shade": "48%"
       }
     }
   }
}
```

and sent normally in the POST body, but unfortunately their HTTP API
only uses GET.

Another use case is to fold elements into a URL-Encoded POST form
when uploading content.