### PR TITLE
RedirectAllTrafficTo and StatusOK helpers

### DIFF
--- a/otils.go
+++ b/otils.go
@@ -200,3 +200,29 @@ func firstJSONTag(v reflect.StructField) string {
 	}
 	return jsonTag
 }
+
+// RedirectAllTrafficTo creates a handler that can be attached
+// to an HTTP traffic multiplexer to perform a 301 Permanent Redirect
+// to the specified host for any path, anytime that the handler
+// receives a request.
+// Sample usage is:
+//
+//  httpsRedirectHandler := RedirectAllTrafficTo("https://orijtech.com")
+//  if err := http.ListenAndServe(":80", httpsRedirectHandler); err != nil {
+//    log.Fatal(err)
+//  }
+//
+// which is used in production at orijtech.com to redirect any non-https
+// traffic from http://orijtech.com/* to https://orijtech.com/*
+func RedirectAllTrafficTo(host string) http.Handler {
+	fn := func(rw http.ResponseWriter, req *http.Request) {
+		finalURL := fmt.Sprintf("%s%s", host, req.URL.Path)
+		rw.Header().Set("Location", finalURL)
+		rw.WriteHeader(301)
+	}
+
+	return http.HandlerFunc(fn)
+}
+
+// StatusOK returns true if a status code is a 2XX code
+func StatusOK(code int) bool { return code >= 200 && code <= 299 }


### PR DESCRIPTION
* RedirectAllTrafficTo is a helper that creates a handler to
perform 301 Permanent Redirects to the specified host for any
path(route) for any traffic that is encountered.
Sample usage in production at orijtech.com is:
```go
httpsRedirectHandler := otils.RedirectAllTrafficTo("https://orijtech.com")
if err := http.ListenAndServe(":80", httpsRedirectHandler); err != nil {
    log.Fatal(err)
}
```
to redirect any non-https traffic from:
+ http://orijtech.com/*
+ http://www.orijtech.com/*

to
+ https://orijtech.com/*

* StatusOK returns true if a status code is in the 200s range ie 2XX
from 200 to 299. It is a common pattern when checking the status of
an HTTP request for success.