### PR TITLE
introduce CodedError

### DIFF
--- a/otils.go
+++ b/otils.go
@@ -254,3 +254,29 @@ func FirstNonEmptyString(args ...string) string {
 	}
 	return ""
 }
+
+type CodedError struct {
+	code int
+	msg  string
+}
+
+func (cerr *CodedError) Error() string {
+	if cerr == nil {
+		return ""
+	}
+	return cerr.msg
+}
+
+func (cerr *CodedError) Code() int {
+	if cerr == nil {
+		return http.StatusOK
+	}
+	return cerr.code
+}
+
+func MakeCodedError(msg string, code int) *CodedError {
+	return &CodedError{
+		msg:  msg,
+		code: code,
+	}
+}

--- a/otils_test.go
+++ b/otils_test.go
@@ -126,3 +126,36 @@ func TestFirstNonEmptyString(t *testing.T) {
 		}
 	}
 }
+
+func TestCodedError(t *testing.T) {
+	// No panics expected
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("unexpected panic: %#v", r)
+		}
+	}()
+
+	tests := [...]struct {
+		err  *otils.CodedError
+		msg  string
+		code int
+	}{
+		0: {otils.MakeCodedError("200 OK", 200), "200 OK", 200},
+		1: {otils.MakeCodedError("failed to find it", 404), "failed to find it", 404},
+
+		// nil CodedError should not panic and should return 200 values.
+		2: {nil, "", 200},
+	}
+
+	for i, tt := range tests {
+		gotCode, wantCode := tt.err.Code(), tt.code
+		if gotCode != wantCode {
+			t.Errorf("#%d gotCode=%v wantCode=%v", i, gotCode, wantCode)
+		}
+
+		gotMsg, wantMsg := tt.err.Error(), tt.msg
+		if gotMsg != wantMsg {
+			t.Errorf("#%d gotMsg=%v wantMsg=%v", i, gotMsg, wantMsg)
+		}
+	}
+}


### PR DESCRIPTION
CodedError encapsulates an error that has both
text/content and a code for example:
* HTTP status errors e.g "Not Found", 404
* Shell return codes e.g "exec failed", 5

The main consumer so far are APIs that need to capture
the HTTP status code as well as the status or body slurped
from an HTTP response.