### PR TITLE
NumericBool implemented

### DIFF
--- a/otils.go
+++ b/otils.go
@@ -338,3 +338,28 @@ func (nf64 *NullableFloat64) UnmarshalJSON(b []byte) error {
 	*nf64 = NullableFloat64(f64)
 	return nil
 }
+
+type NumericBool bool
+
+func (nb *NumericBool) UnmarshalJSON(blob []byte) error {
+	if len(blob) < 1 {
+		*nb = false
+		return nil
+	}
+
+	s := string(blob)
+	// Try first parsing an integer.
+	pBool, err := strconv.ParseBool(s)
+	if err == nil {
+		*nb = NumericBool(pBool)
+		return nil
+	}
+
+	pInt, err := strconv.ParseInt(s, 10, 32)
+	if err != nil {
+		*nb = pInt != 0
+		return nil
+	}
+
+	return err
+}

--- a/otils_test.go
+++ b/otils_test.go
@@ -1,6 +1,7 @@
 package otils_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/orijtech/otils"
@@ -156,6 +157,42 @@ func TestCodedError(t *testing.T) {
 		gotMsg, wantMsg := tt.err.Error(), tt.msg
 		if gotMsg != wantMsg {
 			t.Errorf("#%d gotMsg=%v wantMsg=%v", i, gotMsg, wantMsg)
+		}
+	}
+}
+
+func TestNumericBool(t *testing.T) {
+	tests := [...]struct {
+		str     string
+		want    otils.NumericBool
+		wantErr bool
+	}{
+		0: {str: "1", want: otils.NumericBool(true)},
+		1: {str: "0", want: otils.NumericBool(false)},
+		2: {str: "true", want: otils.NumericBool(true)},
+		3: {str: "false", want: otils.NumericBool(false)},
+		4: {str: "ping", wantErr: true},
+	}
+
+	for i, tt := range tests {
+		var nb otils.NumericBool
+		err := json.Unmarshal([]byte(tt.str), &nb)
+
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("#%d: expecting non-nil error", i)
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("#%d: err: %v", i, err)
+			continue
+		}
+
+		got, want := nb, tt.want
+		if got != want {
+			t.Errorf("#%d got=%v want=%v", i, got, want)
 		}
 	}
 }


### PR DESCRIPTION
I've encountered many APIs returning 1 or 0 for booleans
and this causes Go's encoding/json to barf.

Hence the need to implement NumericBool.