### PR TITLE
.github/workflows: upgrade to Go1.18.X

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.18.x
       - name: Cache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
Allows us to use Go1.18.* in actions/tests.

Unblocks PR #21